### PR TITLE
API Bling pode retornar null no anexo e anexoVinculo

### DIFF
--- a/src/Entities/Produtos/Schema/Find/FindResponseDataMidiaImagensInternas.php
+++ b/src/Entities/Produtos/Schema/Find/FindResponseDataMidiaImagensInternas.php
@@ -20,7 +20,7 @@ readonly final class FindResponseDataMidiaImagensInternas extends BaseResponseOb
         public string $linkMiniatura,
         public string $validade,
         public ?int $ordem,
-        public Id $anexo,
-        public Id $anexoVinculo,
+        public ?Id $anexo,
+        public ?Id $anexoVinculo,
     ) {}
 }


### PR DESCRIPTION
Deixando os campos sem obrigatoriedade, assim permitindo nulls E não causando fatal error.